### PR TITLE
feat: ヘッダーでレスポンスにHTTPステータス要求するオプションと、has_errorがtrueの場合は400を検知できるように

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,48 @@ https://github.com/chikyuinc/chikyu-api-specification
 const chikyu = require('chikyu-sdk');
 ```
 
+## RESTful応答モード（エラー時のHTTPステータスコード返却）
+デフォルトでは、APIエラー（`has_error: true`）でもHTTPステータスは200を返します。
+`setUseHttpStatus(true)`を設定すると、エラー種別に応じたHTTPステータスコードが返却されるようになります。
+
+```javascript
+// RESTful応答モードを有効化
+chikyu.config.setUseHttpStatus(true);
+```
+
+| 設定 | エラー時のHTTPステータス |
+|------|------------------------|
+| `setUseHttpStatus(false)`（デフォルト） | 常に200 |
+| `setUseHttpStatus(true)` | エラー種別に応じたステータス（400/401/403/500等） |
+
+### エラーハンドリング
+
+```javascript
+chikyu.config.setUseHttpStatus(true);
+
+try {
+    const result = await chikyu.signless.invoke('/entity/companies/list', {
+        items_per_page: 10,
+        page_index: 0
+    });
+    // 成功時: result にデータが入る
+} catch (err) {
+    // エラー時: err.httpStatus でエラー種別を判別可能
+    console.log(err.httpStatus);  // 400, 401, 403, 500 等
+    console.log(err.message);     // エラーメッセージ
+    console.log(err.data);        // レスポンスデータ
+
+    if (err.httpStatus === 400) {
+        // バリデーションエラー
+    } else if (err.httpStatus === 401) {
+        // 認証エラー
+    } else if (err.httpStatus === 403) {
+        // 権限エラー
+    }
+}
+```
+
+
 ## 関数
 ```
 chikyu.token.create

--- a/lib/common/config.js
+++ b/lib/common/config.js
@@ -62,6 +62,12 @@ Chikyu.config = {
     },
     setMode: function(mode) {
         this._mode = mode;
+    },
+    useHttpStatus: function() {
+        return this._useHttpStatus || false;
+    },
+    setUseHttpStatus: function(flag) {
+        this._useHttpStatus = !!flag;
     }
 };
 

--- a/lib/common/request.js
+++ b/lib/common/request.js
@@ -9,19 +9,40 @@ Chikyu.request = {
                 'Content-Type': 'application/json'
             };
         }
+        // headersのコピーを作成
+        headers = Object.assign({}, headers);
+        // useHttpStatus()がtrueの場合、Error-Responseヘッダーを追加
+        if (Chikyu.config.useHttpStatus()) {
+            if (!('Error-Response' in headers) && !('error-response' in headers)) {
+                headers['Error-Response'] = 'http-status';
+            }
+        }
         const url = Chikyu.request.buildUrl(apiClass, apiPath, true);
-        return axios.post(url, JSON.stringify(apiData), {
-                    headers: headers
-                }).then((res) => {
+
+        // axiosオプションを構築
+        const axiosOptions = {
+            headers: headers
+        };
+        // useHttpStatus()がtrueの場合、全てのHTTPステータスをresolveさせる
+        if (Chikyu.config.useHttpStatus()) {
+            axiosOptions.validateStatus = function() { return true; };
+        }
+
+        return axios.post(url, JSON.stringify(apiData), axiosOptions).then((res) => {
                     const data = res.data;
+                    const httpStatus = res.status;
                     return new Promise(function(resolve, reject) {
                         try {
-                            if (!('has_error' in data) || data.has_error) {
-                                reject(new Error(data.message));
+                            if (!data || typeof data !== 'object' || !('has_error' in data) || data.has_error) {
+                                const error = new Error((data && data.message) || 'Unknown error');
+                                error.data = data;
+                                error.httpStatus = httpStatus;
+                                reject(error);
                             } else {
                                 resolve(data.data);
                             }
                         } catch (e) {
+                            e.httpStatus = httpStatus;
                             reject(e);
                         }
                 });

--- a/lib/invoke/public.js
+++ b/lib/invoke/public.js
@@ -7,11 +7,12 @@ Chikyu.setApiKeys = function(apiKey, authKey) {
 
 Chikyu.public = {
     invoke: function(apiPath, data) {
-        return Chikyu.request.invoke('public', apiPath, {'data': data},[
-            ['Content-Type', 'application/json'],
-            ['X-Api-Key', Chikyu.apiKey.apiKey],
-            ['X-Auth-Key', Chikyu.apiKey.authKey]
-        ]);
+        const headers = {
+            'Content-Type': 'application/json',
+            'X-Api-Key': Chikyu.apiKey.apiKey,
+            'X-Auth-Key': Chikyu.apiKey.authKey
+        };
+        return Chikyu.request.invoke('public', apiPath, {'data': data}, headers);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chikyu-sdk",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "chikyu SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## PR概要

### JIRA/PRD/Linear 紐づけ

https://geniee.atlassian.net/browse/SFATB-711

### 概要
APIエラー発生時に適切なHTTPステータスコードを取得できるRESTful Response Modeを追加しました。

**重要: 後方互換性は完全に維持されています。** デフォルトでは従来の動作（全レスポンス HTTP 200）のまま変更はありません。明示的に `setUseHttpStatus(true)` を呼び出した場合のみ新機能が有効になります。

### 変更内容
- `Chikyu.config.setUseHttpStatus(true/false)` - RESTfulモードの切り替え
- `Chikyu.config.useHttpStatus()` - 現在のモード取得
- RESTfulモード有効時、エラーオブジェクトに `httpStatus` プロパティを付与

### 使用方法
```javascript
const chikyu = require('chikyu-sdk');

// RESTfulモードを有効化（オプトイン）
chikyu.config.setUseHttpStatus(true);

try {
    await chikyu.signless.invoke('/entity/companies/list', {});
} catch (err) {
    console.log(err.httpStatus);  // 400, 401, 403, 500 など
    console.log(err.message);
    console.log(err.data);
}
```

---

## テストケース

### テスト環境
- Node.js SDK
- 通常モード（`useHttpStatus: false`）とRESTfulモード（`useHttpStatus: true`）の2パターンで実施

### テストケース一覧と結果

| # | テストケース | 説明 | 通常モード | RESTfulモード |
|---|-------------|------|-----------|---------------|
| 1 | companies/list | 正常系（リスト取得） | ✅ 200 | ✅ 200 |
| 2 | companies/create (fieldsなし) | バリデーションエラー | ✅ 200 | ✅ 400 |
| 3 | companies/save (fieldsなし) | バリデーションエラー | ✅ 200 | ✅ 400 |
| 4 | companies/delete (存在しないID) | 存在しないリソース | ✅ 200 | ✅ 400 |
| 5 | companies/list (items_per_pageなし) | 必須パラメータ不足 | ✅ 200 | ✅ 400 |
| 6 | unknown/unknown | 存在しないAPI | ✅ axios_error | ✅ 400 |
| 7 | sandbox/status (HttpError 403) | 認可エラー | ✅ axios_error | ✅ 403 |
| 8 | 無効セッション (401) | 認証エラー | ✅ axios_error | ✅ 401 |
| 9 | 認証ヘッダーなし (API Gateway 403) | X-API-KEYなし | ✅ axios_error | ✅ 403 |
| 10 | 無効なX-API-KEY (API Gateway 403) | 無効なAPIキー | ✅ axios_error | ✅ 403 |

### 結果サマリー
- **通常モード**: 10/10 PASS
- **RESTfulモード**: 10/10 PASS
- **総合結果**: ALL PASS

https://geniee.atlassian.net/browse/SFATB-711?focusedCommentId=432493

### 備考
- `axios_error`: 通常モードではHTTPエラーがaxiosのrejectとして返却される（従来動作）
- RESTfulモードでは全てのエラーが `err.httpStatus` で取得可能
- API Gatewayレベルのエラー（`has_error`プロパティなし）も正しくハンドリングされることを確認



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * エラー応答時のHTTPステータス挙動を切替可能に（既定は200、切替で400/401/403/500等を返却可能）。
  * レスポンス／エラーにHTTPステータス情報が含まれ、クライアントで取得・伝搬可能に。

* **ドキュメント**
  * READMEに設定方法・利用例・設定と結果の対応表・エラー処理例を追記。

* **その他**
  * パッケージバージョンを1.1.0へ更新。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->